### PR TITLE
Improved fallback expiry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '14'
-          - '16'
-          - '18'
           - '20'
           - '22'
 

--- a/example-named-pipe.js
+++ b/example-named-pipe.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const { pipeline } = require('stream')
+const ndjson = require('ndjson')
+const {join} = require('path')
+const fs = require('fs')
+const net = require('net');
+const {gtfsRtDifferentialToFullDataset} = require('.')
+
+const toFullDataset = gtfsRtDifferentialToFullDataset({
+	ttl: 1 * 60 * 60 * 1000, // 1 hour
+	requireDifferentialInput: false,
+})
+
+const writeFull = () => {
+	fs.writeFile('/gtfsrt/latest.gtfs-rt.pbf.temp', toFullDataset.asFeedMessage(), err => {
+		if (err) {
+			console.error(err);
+		} else {
+			// mv to emulate atomic write to avoid garbled reads for consumers of /gtfsrt/latest.gtfs-rt.pbf
+			fs.rename('/gtfsrt/latest.gtfs-rt.pbf.temp', '/gtfsrt/latest.gtfs-rt.pbf', function (err) {
+				if (err) console.log(err);
+				console.log('written', toFullDataset.timeModified(), toFullDataset.nrOfEntities());
+			});
+		}
+	});
+}
+
+toFullDataset.on('change', () => {
+	// write full feed on every update
+	writeFull();
+})
+
+// Creating a named pipe that differential updates can be read from: `mkfifo ndjsonpipe`
+// You can then send updates with sth like `cat differential.gtfs-rt.pbf | npx print-gtfs-rt-cli -j -a > ndjsonpipe`
+fs.open(join(__dirname, 'ndjsonpipe'), fs.constants.O_RDWR | fs.constants.O_NONBLOCK, (err, fd) => {
+	pipeline(
+		new net.Socket({ fd }),		
+		ndjson.parse(),
+		toFullDataset,
+		(err) => {
+			if (err) {
+				console.log(err)
+				//process.exit(1)
+			} else {
+				console.log('terminated');
+				writeFull();
+			}
+		}
+	)
+});

--- a/example.js
+++ b/example.js
@@ -2,9 +2,9 @@
 
 const pump = require('pump')
 const ndjson = require('ndjson')
-const differentialToFullDataset = require('.')
+const {gtfsRtDifferentialToFullDataset} = require('.')
 
-const toFullDataset = differentialToFullDataset({
+const toFullDataset = gtfsRtDifferentialToFullDataset({
 	ttl: 2 * 60 * 1000, // 2 minutes
 })
 

--- a/index.js
+++ b/index.js
@@ -26,10 +26,41 @@ const tripSignature = (u) => {
 	return null
 }
 
-const defaultTripUpdateExpiresAt = (tU, getNow, defaultTtl) => {
+const tryParseStartDateTime = (tU, getNow) => {
+	const now = getNow();
+	if (tU.trip && tU.trip.start_date && tU.trip.start_date.length == 8) {
+		const start_date = tU.trip.start_date;
+		const parts = [
+			parseInt(start_date.substring(0,4)) || 0,
+			(parseInt(start_date.substring(4,6)) || 1)-1,
+			parseInt(start_date.substring(6,8)) || 1
+		];
+		if (tU.trip.start_time) {
+			const time = tU.trip.start_time.split(':')
+			if (time.length == 3) {
+				parts.push(parseInt(time[0]) || 0, parseInt(time[1]) || 0, parseInt(time[2]) || 0);
+			}
+		}
+		const parsed = new Date(...parts).getTime()/1000
+		return Math.max(parsed, now)
+	}
+	return now;
+}
+
+const estimateTripEndTime = (tU, getNow, defaultTripDuration) => {
+	return tryParseStartDateTime(tU, getNow) + defaultTripDuration;
+}
+
+const defaultTripUpdateExpiresAt = (tU, getNow, defaultTtl, canceledTtl, fallbackTripDuration) => {
 	let maxArrDep = -1
+	if (tU.trip && tU.trip.schedule_relationship == 3) { // CANCELED
+		maxArrDep = estimateTripEndTime(tU, getNow, fallbackTripDuration) + canceledTtl
+	}
 	if (Array.isArray(tU.stop_time_update)) {
 		for (const sTU of tU.stop_time_update) {
+			if (sTU.schedule_relationship == 1) { // SKIPPED
+				maxArrDep = Math.max(maxArrDep, estimateTripEndTime(tU, getNow, fallbackTripDuration) + canceledTtl)
+			}
 			if (sTU.arrival && Number.isInteger(sTU.arrival.time)) {
 				maxArrDep = Math.max(maxArrDep, sTU.arrival.time)
 			}
@@ -42,11 +73,10 @@ const defaultTripUpdateExpiresAt = (tU, getNow, defaultTtl) => {
 		return maxArrDep + defaultTtl
 	}
 
-	// todo: fall back to tU.trip.start_{date,time} + buffer if available? – handle canceled trips without sTUs!
 	if (Number.isInteger(tU.timestamp)) {
-		return tU.timestamp + defaultTtl
+		return tU.timestamp + fallbackTripDuration + defaultTtl
 	}
-	return getNow() + defaultTtl
+	return estimateTripEndTime(tU, getNow, fallbackTripDuration) + defaultTtl
 }
 
 const defaultVehiclePositionExpiresAt = (vP, getNow, defaultTtl) => {
@@ -70,6 +100,9 @@ const defaultAlertExpiresAt = (alert, getNow, defaultTtl) => {
 const gtfsRtDifferentialToFullDataset = (opt = {}) => {
 	const {
 		ttl: defaultTtlMs,
+		canceledTtl : defaultCanceledTtlMs,
+		fallbackTripDuration: defaultFallbackTripDurationMs,
+		requireDifferentialInput,
 		timestamp: getNow,
 		tripUpdateSignature,
 		vehiclePositionSignature,
@@ -79,6 +112,9 @@ const gtfsRtDifferentialToFullDataset = (opt = {}) => {
 		alertExpiresAt,
 	} = {
 		ttl: 5 * 60 * 1000, // 5 minutes
+		canceledTtl: 24 * 60 * 60 * 1000, // 24 hours
+		fallbackTripDuration: 6 * 60 * 60 * 1000, // 6 hours
+		requireDifferentialInput: true,
 		timestamp: () => Date.now() / 1000 | 0,
 		tripUpdateSignature: (u) => {
 			const tripSig = tripSignature(u)
@@ -103,11 +139,13 @@ const gtfsRtDifferentialToFullDataset = (opt = {}) => {
 		...opt
 	}
 	const defaultTtl = Math.round(defaultTtlMs / 1000)
+	const canceledTtl = Math.round(defaultCanceledTtlMs / 1000)
+	const fallbackTripDuration = Math.round(defaultFallbackTripDurationMs / 1000)
 
 	const entityExpiresAt = (entity) => {
 		let expiresAt = -1
 		if (entity.trip_update) {
-			const _expiresAt = tripUpdateExpiresAt(entity.trip_update, getNow, defaultTtl)
+			const _expiresAt = tripUpdateExpiresAt(entity.trip_update, getNow, defaultTtl, canceledTtl, fallbackTripDuration)
 			Number.isInteger(_expiresAt, 'tripUpdateExpiresAt() must return an integer or null')
 			expiresAt = Math.max(expiresAt, _expiresAt)
 		}
@@ -160,7 +198,7 @@ const gtfsRtDifferentialToFullDataset = (opt = {}) => {
 			err.feedMessage = msg
 			throw err
 		}
-		if (msg.header.incrementality !== DIFFERENTIAL) {
+		if (msg.header.incrementality !== DIFFERENTIAL && requireDifferentialInput) {
 			const err = new UnsupportedFeedMessageError('FeedMessage must be DIFFERENTIAL')
 			err.feedMessage = msg
 			throw err

--- a/index.js
+++ b/index.js
@@ -15,11 +15,16 @@ class UnsupportedKindOfFeedEntityError extends Error {}
 
 class FeedEntitySignatureError extends Error {}
 
+const getGtfsRtDateNow = () => {
+	const d = new Date();
+	return `${d.getFullYear()}${(d.getMonth() + 1).toString().padStart(2, '0')}${d.getDate().toString().padStart(2, '0')}`;
+}
+
 const tripSignature = (u) => {
-	if (u.trip.trip_id && u.trip.start_date) {
-		return u.trip.trip_id + '-' + u.trip.start_date
+	if (u.trip.trip_id) {
+		return u.trip.trip_id + '-' + (u.trip.start_date || getGtfsRtDateNow())
 	}
-	if (u.trip.route_id && u.vehicle.id) {
+	if (u.trip.route_id && u.vehicle && u.vehicle.id) {
 		return u.trip.route_id + '-' + u.vehicle.id
 	}
 	// todo: u.trip.route_id + slugg(u.vehicle.label) ?

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 'use strict'
 
+const createDebug = require('debug')
 const {FeedHeader} = require('gtfs-rt-bindings')
 const {Writable} = require('stream')
 const createEntitiesStore = require('./lib/entities-store')
 
 const {DIFFERENTIAL} = FeedHeader.Incrementality
+
+const debug = createDebug('gtfs-rt-differential-to-full-dataset')
 
 class UnsupportedFeedMessageError extends Error {}
 
@@ -143,6 +146,7 @@ const gtfsRtDifferentialToFullDataset = (opt = {}) => {
 
 		if (sig !== null) {
 			const expiresAt = entityExpiresAt(entity)
+			debug('storing entity', sig, 'expiresAt', expiresAt, 'entity', entity)
 			entitiesStore.put(sig, entity, expiresAt)
 			return;
 		}

--- a/lib/entities-store.js
+++ b/lib/entities-store.js
@@ -47,8 +47,10 @@ const createEntitiesStore = (now) => {
 	let timestamps = []
 	const timestampsById = new Map()
 	let cache = null // cached final `FeedMessage` buffer
+	let lastMod = now()
 
 	const del = (id, debugLog = true) => {
+		const t0 = now()
 		if (debugLog) debug('del', id)
 		if (!datas.has(id)) {
 			if (debugLog) debug('entity does not exist', id)
@@ -66,16 +68,17 @@ const createEntitiesStore = (now) => {
 			timestampsById.delete(id)
 		}
 		cache = null
+		lastMod = t0
 	}
 
 	const put = (id, entity, expiresAt) => {
+		const t0 = now()
 		debug('put', id, entity, expiresAt)
 		del(id, false)
-		cache = null
 
 		if (expiresAt !== null) {
 			ok(Number.isInteger(expiresAt), 'expiresAt must be an integer or null')
-			const timeLeft = (expiresAt - now()) * 1000
+			const timeLeft = (expiresAt - t0) * 1000
 			if(timeLeft <= 0) {
 				debug('ignoring already expired entity', id, entity, expiresAt, timeLeft)
 				return;
@@ -91,8 +94,12 @@ const createEntitiesStore = (now) => {
 					// note: not available in browsers
 					timer.unref()
 				}
+			} else {
+				// todo: what else? – periodic interval, setting timeouts for soon-to-expire entities?
 			}
 		}
+
+		cache = null
 
 		FeedEntity.verify(entity)
 		const data = FeedEntity.encode(entity).finish()
@@ -111,9 +118,11 @@ const createEntitiesStore = (now) => {
 		timestampsById.set(id, timestamp)
 
 		cache = null
+		lastMod = t0
 	}
 
 	const flush = () => {
+		const t0 = now()
 		debug('flush')
 		for (const timer of timers.values()) clearTimeout(timer)
 		timers.clear()
@@ -122,6 +131,7 @@ const createEntitiesStore = (now) => {
 		timestamps = []
 		timestampsById.clear()
 		cache = null
+		lastMod = t0
 	}
 
 	const nrOfEntities = () => datas.size
@@ -129,7 +139,7 @@ const createEntitiesStore = (now) => {
 	const getTimestamp = () => {
 		return timestamps.length > 0
 			? timestamps[timestamps.length - 1] // highest
-			: now()
+			: lastMod
 	}
 
 	const asFeedMessage = () => {

--- a/lib/entities-store.js
+++ b/lib/entities-store.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const createDebug = require('debug')
 const {ok} = require('assert')
 const schema = require('gtfs-rt-bindings/gtfs-realtime.schema.json')
 const {varint} = require('protocol-buffers-encodings')
@@ -13,6 +14,8 @@ const FEED_MSG_ENTITIES = feedMsgFields.entity.id
 
 // https://developers.google.com/protocol-buffers/docs/encoding#structure
 const LENGTH_DELIMITED = 2
+
+const debug = createDebug('gtfs-rt-differential-to-full-dataset:entities-store')
 
 // https://developers.google.com/protocol-buffers/docs/encoding#structure
 const encodeField = (fieldNumber, wireType, dataLength) => {
@@ -45,8 +48,12 @@ const createEntitiesStore = (now) => {
 	const timestampsById = new Map()
 	let cache = null // cached final `FeedMessage` buffer
 
-	const del = (id) => {
-		if (!datas.has(id)) return;
+	const del = (id, debugLog = true) => {
+		if (debugLog) debug('del', id)
+		if (!datas.has(id)) {
+			if (debugLog) debug('entity does not exist', id)
+			return;
+		}
 		if (timers.has(id)) {
 			clearTimeout(timers.get(id))
 			timers.delete(id)
@@ -62,15 +69,15 @@ const createEntitiesStore = (now) => {
 	}
 
 	const put = (id, entity, expiresAt) => {
-		// console.error('put', id, entity) // todo: remove
-		del(id)
+		debug('put', id, entity, expiresAt)
+		del(id, false)
 		cache = null
 
 		if (expiresAt !== null) {
 			ok(Number.isInteger(expiresAt), 'expiresAt must be an integer or null')
 			const timeLeft = (expiresAt - now()) * 1000
 			if(timeLeft <= 0) {
-				// already expired, so we don't insert it
+				debug('ignoring already expired entity', id, entity, expiresAt, timeLeft)
 				return;
 			}
 			// > When delay is larger than 2147483647 […], the delay will be set to 1.
@@ -107,6 +114,7 @@ const createEntitiesStore = (now) => {
 	}
 
 	const flush = () => {
+		debug('flush')
 		for (const timer of timers.values()) clearTimeout(timer)
 		timers.clear()
 		datas.clear()

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"bugs": "https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset/issues",
 	"license": "ISC",
 	"engines": {
-		"node": ">=14"
+		"node": ">=20"
 	},
 	"dependencies": {
 		"gtfs-rt-bindings": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "gtfs-rt-differential-to-full-dataset",
 	"description": "Transform a differential GTFS Realtime feed into a full dataset/dump.",
-	"version": "2.1.2",
+	"version": "3.0.0-alpha.0",
 	"main": "index.js",
 	"files": [
 		"index.js",
@@ -16,7 +16,7 @@
 		"differential"
 	],
 	"author": "Jannis R <mail@jannisr.de>",
-	"homepage": "https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset",
+	"homepage": "https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset/tree/3.0.0-alpha.0",
 	"repository": "derhuerst/gtfs-rt-differential-to-full-dataset",
 	"bugs": "https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset/issues",
 	"license": "ISC",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"node": ">=20"
 	},
 	"dependencies": {
+		"debug": "^4.4.0",
 		"gtfs-rt-bindings": "^4.0.0",
 		"protocol-buffers-encodings": "^1.1.0",
 		"sorted-array-functions": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "gtfs-rt-differential-to-full-dataset",
-	"description": "Transform a differential GTFS Realtime feed into a full dataset/dump.",
-	"version": "3.0.0-alpha.0",
+	"description": "Transform a stream of DIFFERENTIAL-mode GTFS Realtime (GTFS-RT) FeedEntities into a FULL_DATASET-mode feed.",
+	"version": "3.0.0-alpha.1",
 	"main": "index.js",
 	"files": [
 		"index.js",
@@ -16,7 +16,7 @@
 		"differential"
 	],
 	"author": "Jannis R <mail@jannisr.de>",
-	"homepage": "https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset/tree/3.0.0-alpha.0",
+	"homepage": "https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset/tree/3.0.0-alpha.1",
 	"repository": "derhuerst/gtfs-rt-differential-to-full-dataset",
 	"bugs": "https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset/issues",
 	"license": "ISC",

--- a/test/index.js
+++ b/test/index.js
@@ -117,6 +117,21 @@ store.flush()
 feedMsgEqual(store, [], timestamp(), 'after flush()') // todo: this is flaky
 
 
+{
+	let t = 1
+	const timestamp = () => ++t
+
+	const store = createEntitiesStore(timestamp)
+	feedMsgEqual(store, [], t, 'init')
+
+	store.put('foo', e1, t + ttl)
+	store.put('bar', e2, t + ttl)
+	feedMsgEqual(store, [e1, e2], e1.vehicle.timestamp, 'after put(foo) & put(bar)')
+
+	store.flush()
+	feedMsgEqual(store, [], t, 'after flush()')
+}
+
 
 const full = gtfsRtDifferentialToFullDataset({ttl, timestamp})
 


### PR DESCRIPTION
Resolving the "todo: fall back to tU.trip.start_{date,time} + buffer if available? – handle canceled trips without sTUs!".

I think it is imperative to have very long ttls for cancelled trips, since these are in some way the most important realtime updates and they might be known longer beforehand, i.e. the fallback based on getNow() when no `start_time` is available (which is usually not available) is dangerous. Correct me if I'm wrong, but in the current impl, cancelled trips are basically never ending up in the output feed, or more precisely only for 5 min/the `ttl`. Unless they are usually coming repeatedly in the DIFFERENTIAL input? (Your VBB feed does have astoundingly few/no cancelled trips when I checked.)

Another note: Depending on how you generate the input ndjson, [`sTU.arrival.time`](https://github.com/derhuerst/gtfs-rt-differential-to-full-dataset/blob/b3763061a87a41d0d3a4aed114d791dae4c3522d/index.js#L64) may never be an integer, at least when generating it with [print-gtfs-rt-cli](https://github.com/derhuerst/print-gtfs-rt-cli), because then it looks like `"time":{"low":1736496420,"high":0,"unsigned":false}`. And for feeds using relative `delay` instead of `time`, the fallback with the `fallbackTripDuration` will also always be used, so it also needs to be very long (maybe 6 hours is still too short). I have not found any hint in the draft standard on how to handle this.

From my experience in the last days, a ttl of 6 hours still only uses a couple of hundred MB of RAM even for big feeds like DELFI.

Since I fiddled around quite a bit with that, I have also added an example to read input from other processes via a named pipe and write the full feed to disk on every update.